### PR TITLE
Fix aplying sof-debug file

### DIFF
--- a/setup-audio
+++ b/setup-audio
@@ -126,7 +126,7 @@ def sof_audio(platform):
     if args.debug:
         print_status(f"{args.debug} SOF debugging")
         if args.debug == "Enabling":
-            cpfile("conf/sof/alsa-sof-dbg.conf", "/etc/modprobe.d/snd-sof-dbg.conf")
+            cpfile("conf/sof/snd-sof-dbg.conf", "/etc/modprobe.d/snd-sof-dbg.conf")
         else:
             rmfile("/etc/modprobe.d/snd-sof-dbg.conf")
         print_status("Done, please reboot for changes to take effect.")


### PR DESCRIPTION
The current code to copy the [sof debug file](https://github.com/WeirdTreeThing/chromebook-linux-audio/blob/983cba53f16c496d00e23dd832a495b1ae5d354f/setup-audio#L129) uses `alsa-sof-dbg-conf` even though the actual file is `snd-sof-dbg-conf`. 