### PR TITLE
Move debian kernel prompt before platform specific configs.

### DIFF
--- a/setup-audio
+++ b/setup-audio
@@ -70,8 +70,7 @@ def install_deb_kernel():
         urlretrieve(url=deb_kernel_url, filename="/tmp/debian-chrultrabook-kernel.deb")
         bash("apt install -y /tmp/debian-chrultrabook-kernel.deb")
         rmfile("/tmp/debian-chrultrabook-kernel.deb")
-        print_status("Kernel installed, please reboot for changes to take effect.")
-        exit()
+        print_status("Kernel installed")
     except:
         print_error("Error: Failed to install kernel")
 

--- a/setup-audio
+++ b/setup-audio
@@ -180,7 +180,14 @@ def avs_audio():
     if not override_avs:
         rmfile("/lib/firmware/intel/avs/max98357a-tplg.bin")
 
-    if not path_exists(f"/lib/modules/{bash('uname -r')}/kernel/sound/soc/intel/avs"):
+    # Check for kernels with avs module enabled
+    kernels_installed = sp.check_output("ls /lib/modules/", shell=True, text=True).strip().split('\n')
+    has_avs = False
+    for kernel_version in kernels_installed:
+        if path_exists(f"/lib/modules/{kernel_version}/kernel/sound/soc/intel/avs"):\
+            has_avs = True
+
+    if not has_avs:
         print_error("Looks like your kernel doesn't have the avs modules. Make sure you are on at least 6.0 with avs enabled")
         exit(0)
 

--- a/setup-audio
+++ b/setup-audio
@@ -70,6 +70,11 @@ def install_deb_kernel():
         urlretrieve(url=deb_kernel_url, filename="/tmp/debian-chrultrabook-kernel.deb")
         bash("apt install -y /tmp/debian-chrultrabook-kernel.deb")
         rmfile("/tmp/debian-chrultrabook-kernel.deb")
+        print_warning("Kernel installed. Please reboot and rerun this script to complete setup")
+        if input("Would you like to reboot now? [Y/n] ").lower() != "n":
+            print_warning("Restarting device")
+            bash("reboot")
+            exit()
     except:
         print_error("Error: Failed to install kernel")
 
@@ -289,10 +294,6 @@ if __name__ == "__main__":
 
     # Important message
     print_warning("WARNING: You may run into audio issues, even after running this script. Please report any issues on github.")
-    
-    # platform specific configuration
-    board = get_board()
-    match_platform(board)
 
     # Prompt debian users to install a custom kernel
     with open("/etc/os-release", "r") as file:
@@ -302,6 +303,10 @@ if __name__ == "__main__":
         print_status("NOTE: Most devices need a custom kernel for functional audio on Debian and distros based on Debian like LMDE")
         if input("Would you like the script to automatically install this kernel? [Y/n] ").lower() != "n":
             install_deb_kernel()
+
+    # platform specific configuration
+    board = get_board()
+    match_platform(board)
 
     # UCM
     install_ucm()

--- a/setup-audio
+++ b/setup-audio
@@ -70,11 +70,8 @@ def install_deb_kernel():
         urlretrieve(url=deb_kernel_url, filename="/tmp/debian-chrultrabook-kernel.deb")
         bash("apt install -y /tmp/debian-chrultrabook-kernel.deb")
         rmfile("/tmp/debian-chrultrabook-kernel.deb")
-        print_warning("Kernel installed. Please reboot and rerun this script to complete setup")
-        if input("Would you like to reboot now? [Y/n] ").lower() != "n":
-            print_warning("Restarting device")
-            bash("reboot")
-            exit()
+        print_status("Kernel installed, please reboot for changes to take effect.")
+        exit()
     except:
         print_error("Error: Failed to install kernel")
 


### PR DESCRIPTION
This makes the script prompt users to install the debian kernel with avs configs enabled before trying to set platform specific configs.

I also added a prompt for the script to restart the device after installing the kernel.

---

This should resolve #72 and #66 