### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See the [Chrultrabook docs](https://docs.chrultrabook.com/docs/firmware/supporte
 6. Linux Mint 
 7. OpenSUSE
 8. Void Linux
+9. Gentoo Linux
 
 # Other Distros
 Other distros will likely work but will require you to manually install packages.


### PR DESCRIPTION
Hi,

I installed gentoo on this hp Chromebook x360 14c and installed sof-firmware and tried for about 2 days on the forums and other places to get sound to work and i couldn't at all. i went to 3 different distros and they worked cause i used the Chromebook sound script for Chromebooks and it worked automatically. I used the script on this Gentoo install and it worked instantly. Please update for Gentoo Linux also