### PR TITLE
Add new headroom config for wireplumber 0.5 

### DIFF
--- a/conf/avs/51-avs-dmic.conf
+++ b/conf/avs/51-avs-dmic.conf
@@ -1,0 +1,14 @@
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.nick = "Internal Microphone"
+      }
+    ]
+    actions = {
+      update-props = {
+        audio.format = "S16LE"
+      }
+    }
+  }
+]

--- a/conf/common/51-increase-headroom.conf
+++ b/conf/common/51-increase-headroom.conf
@@ -1,0 +1,14 @@
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.name = "~alsa_output.*"
+      }
+    ]
+    actions = {
+      update-props = {
+        api.alsa.headroom = 4096
+      }
+    }
+  }
+]

--- a/setup-audio
+++ b/setup-audio
@@ -319,8 +319,15 @@ if __name__ == "__main__":
     # fixes instability and crashes on various devices
     if path_exists("/usr/bin/wireplumber"):
       print_status("Increasing alsa headroom (fixes instability)")
-      mkdir("/etc/wireplumber/main.lua.d/", create_parents=True)
-      cpfile("conf/common/51-increase-headroom.lua", "/etc/wireplumber/main.lua.d/51-increase-headroom.lua")
+
+      # This is needed since newer wireplumber versions 0.5+ use a different configuration format
+      if "0.4" in sp.check_output("wireplumber -v", shell=True, text=True).strip():
+          mkdir("/etc/wireplumber/main.lua.d/", create_parents=True)
+          cpfile("conf/common/51-increase-headroom.lua", "/etc/wireplumber/main.lua.d/51-increase-headroom.lua")
+      else:
+         mkdir("/etc/wireplumber/wireplumber.conf.d/", create_parents=True)
+         cpfile("conf/common/51-increase-headroom.conf", "/etc/wireplumber/wireplumber.conf.d/51-increase-headroom.conf")
+         
 
     # ubuntu moment :skull:
     if distro.lower().__contains__("ubuntu_codename") and not distro.lower().__contains__("pop"):

--- a/setup-audio
+++ b/setup-audio
@@ -159,8 +159,13 @@ def avs_audio():
     # Install wireplumber config for dmic if wireplumber is installed on the system
     if path_exists("/usr/bin/wireplumber"):
         print_status("Forcing avs_dmic to use S16LE format")
-        mkdir("/etc/wireplumber/main.lua.d/", create_parents=True)
-        cpfile("conf/avs/51-avs-dmic.lua", "/etc/wireplumber/main.lua.d/51-avs-dmic.lua")
+      # This is needed since newer wireplumber versions 0.5+ use a different configuration format
+        if "0.4" in sp.check_output("wireplumber -v", shell=True, text=True).strip():
+            mkdir("/etc/wireplumber/main.lua.d/", create_parents=True)
+            cpfile("conf/avs/51-avs-dmic.lua", "/etc/wireplumber/main.lua.d/51-avs-dmic.lua")
+        else:
+            mkdir("/etc/wireplumber/wireplumber.conf.d/", create_parents=True)
+            cpfile("conf/common/51-avs-dmic.conf", "/etc/wireplumber/wireplumber.conf.d/51-avs-dmic.conf")
 
     # updated avs dsp firmware recently got merged upstream but is not packaged in any distro yet
     print_status("Installing AVS firmware")


### PR DESCRIPTION
This is needed since wireplumber 0.5 switched to a new configuration format and the lua script no longer works.