### PR TITLE
Added the board "marasov"

### DIFF
--- a/conf/boards.json
+++ b/conf/boards.json
@@ -207,6 +207,7 @@
   "kinox": "adl",
   "kuldax": "adl",
   "lisbon": "adl",
+  "marasov": "adl",
   "mithrax": "adl",
   "moli": "adl",
   "omnigul": "adl",


### PR DESCRIPTION
I don't know how to code so I don't fully understand this script, I just wanted to share my fix for my Asus CX34 Chromebook plus. My fork now fixes wired and bluetooth headphones but the internal speakers are still distorted at all volumes in alsa-mixer and Youtube's player controls. I tested using a fresh install of Fedora 40.

"ASUS Chromebook Plus CX34" "MARASOV" is listed here;
https://docs.chrultrabook.com/docs/firmware/supported-devices.html

