### PR TITLE
Fix typo

### DIFF
--- a/setup-audio
+++ b/setup-audio
@@ -63,6 +63,6 @@ if __name__ == "__main__":
     bash("alsactl init; true")
 
     print_status("Audio setup finished! Reboot to complete setup.")
-    if check_os_relase():
+    if check_os_release():
         print_status("If you still have any issues post-reboot, report them to https://github.com/WeirdTreeThing/chromebook-linux-audio")
         print_status("If this script has been helpful for you and you would like to support the work I do, consider donating to https://paypal.me/weirdtreething")


### PR DESCRIPTION
Hi, i noticed that in commit [b470ccb53ff7da1bfff68841ab498426dedbf13b](https://github.com/WeirdTreeThing/chromebook-linux-audio/commit/b470ccb53ff7da1bfff68841ab498426dedbf13b) you added a distro warning. In setup-audio you misspelled the function "check_os_release" as "check_os_relase".

Really good work btw, thank you for creating this repo.

I'm not English, so I if I wrote something wrong I'm sorry