### PR TITLE
disable deprecated board name argument

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -114,6 +114,9 @@ def print_question(message: str) -> None:
 def print_header(message: str) -> None:
     print("\033[95m" + message + "\033[0m", flush=True)
 
+def print_info(message: str) -> None:
+    print("\033[96m" + message + "\033[0m", flush=True)
+
 #######################################################################################
 #                             PACKAGE MANAGER FUNCTIONS                               #
 #######################################################################################

--- a/setup-audio
+++ b/setup-audio
@@ -60,6 +60,12 @@ if __name__ == "__main__":
     print_status("Initializing sound card")
     bash("alsactl init; true")
 
+    # Clear WirePlumber state to ensure fresh device detection
+    print_info("Clearing audio session state")
+    bash("rm -rf ~/.local/state/wireplumber/")
+    bash("rm -rf ~/.config/pulse/")
+    # Note: Not deleting ~/.config/pipewire/ to preserve user customizations
+
     print_status("Audio setup finished! Reboot to complete setup.")
     if check_os_release():
         print_status("If you still have any issues post-reboot, report them to https://github.com/WeirdTreeThing/chromebook-linux-audio")

--- a/setup-audio
+++ b/setup-audio
@@ -8,8 +8,6 @@ from functions import *
 # parse arguments from the cli. Only for testing/advanced use.
 def process_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-b", dest="board_name", type=str, nargs=1, default=[""],
-                        help="Override board name.")
     parser.add_argument("--enable-debug", action='store_const', const="Enabling", dest="debug",
                         help="Enable audio debugging.")
     parser.add_argument("--disable-debug", action='store_const', const="Disabling", dest="debug",


### PR DESCRIPTION
It seems the option was left there from earlier times but now no longer user or needed.
The second commit removes some files which were creating problems for me and were preventing the sound from working. 
 Removing this stale config from wireplumber made everything work as in should.